### PR TITLE
Add text-attributed dataset loading utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # Master-Thesis
+
+Utilities for text-attributed graph processing with large language models (LLMs).
+
+## Setup
+
+Install dependencies (requires PyTorch and Torch-Geometric):
+
+```bash
+pip install -r requirements.txt
+```
+
+## Loading datasets
+
+Run `load_datasets.py` to download and preprocess the Cora, PubMed and Arxiv datasets:
+
+```bash
+python load_datasets.py
+```
+
+The script will create a `data/` directory containing the processed graph data with textual node attributes.

--- a/datasets/text_graph_dataset.py
+++ b/datasets/text_graph_dataset.py
@@ -1,0 +1,48 @@
+"""Text-attributed graph dataset utilities using PyTorch Geometric."""
+
+from typing import List
+from pathlib import Path
+
+import torch
+from torch_geometric.data import InMemoryDataset, Data
+from torch_geometric.datasets import Planetoid, OGBNArxiv
+
+
+class TextGraphDataset(InMemoryDataset):
+    """Load and preprocess graph datasets with textual node attributes."""
+
+    def __init__(self, name: str, root: str = "data", **kwargs):
+        self.dataset_name = name.lower()
+        self.root_dir = Path(root) / self.dataset_name
+        super().__init__(root=str(self.root_dir), **kwargs)
+        self.data, self.slices = torch.load(self.processed_paths[0])
+
+    @property
+    def processed_file_names(self) -> List[str]:
+        return ["data.pt"]
+
+    def download(self):  # pragma: no cover - uses built-in datasets
+        pass
+
+    def process(self):
+        if self.dataset_name in {"cora", "pubmed"}:
+            dataset = Planetoid(root=str(self.root_dir), name=self.dataset_name.capitalize())
+            data = dataset[0]
+            data.text = self._bow_to_text(data.x)
+        elif self.dataset_name == "arxiv":
+            dataset = OGBNArxiv(root=str(self.root_dir))
+            data = dataset[0]
+            data.text = self._bow_to_text(data.x)
+        else:
+            raise ValueError(f"Unknown dataset: {self.dataset_name}")
+
+        torch.save(self.collate([data]), self.processed_paths[0])
+
+    @staticmethod
+    def _bow_to_text(x: torch.Tensor) -> List[str]:
+        """Convert bag-of-words vectors to space separated word tokens."""
+        tokens = []
+        for row in x:
+            idx = row.nonzero(as_tuple=False).view(-1).tolist()
+            tokens.append(" ".join(f"word_{i}" for i in idx))
+        return tokens

--- a/load_datasets.py
+++ b/load_datasets.py
@@ -1,0 +1,13 @@
+"""Example script showing how to load text-attributed graph datasets."""
+
+from datasets.text_graph_dataset import TextGraphDataset
+
+
+if __name__ == "__main__":
+    for name in ["cora", "pubmed", "arxiv"]:
+        print(f"Loading {name} dataset")
+        dataset = TextGraphDataset(name=name)
+        data = dataset[0]
+        print(data)
+        print(f"Sample text attribute for node 0: {data.text[0][:100]}\n")
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+torch
+torch_geometric
+ogb


### PR DESCRIPTION
## Summary
- load Cora, PubMed and Arxiv datasets with a custom `TextGraphDataset`
- provide example `load_datasets.py` script
- document setup instructions in README
- include Python requirements

## Testing
- `python -m py_compile datasets/text_graph_dataset.py load_datasets.py`

------
https://chatgpt.com/codex/tasks/task_e_6874c3dcd994832fa5290ae0f768b2b6